### PR TITLE
Fix: import type eslint warning

### DIFF
--- a/packages/ui/turbo/generators/config.ts
+++ b/packages/ui/turbo/generators/config.ts
@@ -1,4 +1,4 @@
-import { PlopTypes } from "@turbo/gen";
+import type { PlopTypes } from "@turbo/gen";
 
 // Learn more about Turborepo Generators at https://turbo.build/repo/docs/core-concepts/monorepos/code-generation
 


### PR DESCRIPTION
Fix eslint warning: `All imports in the declaration are only used as types. Use import type.`